### PR TITLE
Documentation and Enum support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 *.egg-info/
 .pytest_cache/
 .tox/
+.vscode/
+*.venv

--- a/README.md
+++ b/README.md
@@ -7,3 +7,81 @@
 
 
 Hacky implementation of [PEP 224](https://www.python.org/dev/peps/pep-0224/).
+
+## Usage
+
+This package provides the following functions:
+- `attributes_doc`
+- `get_attributes_doc`
+- `enum_doc`
+- `getdoc`
+
+### Decorator `attributes_doc`
+
+This function is a class decorator, and using it on a class will set class attributes called `__doc_ATTRNAME__` for each existing attribute.
+
+```py
+from attributes_doc import attributes_doc
+
+@attributes_doc
+class Foo:
+	bar = 1
+	"""This is the docstring for the bar attribute.
+
+	It will be stored in `Foo.__doc_bar__` and will be accessible at runtime.
+	"""
+
+	baz = 2
+	"""This is the docstring for the baz attribute."""
+
+
+print(Foo.__doc_bar__)
+print(getattr(Foo, "__doc_baz__"))
+```
+
+### Function `get_attributes_doc`
+
+This function will return a dictionary with the docstrings for all attributes of a class without setting them.
+
+```py
+from attributes_doc import get_attributes_doc
+
+class Goo:
+	"""This class doesn't use attributes_doc and we don't want to modify it at all."""
+	bar = 1
+	"""This is the docstring for the bar attribute."""
+	baz = 2
+	"""This is the docstring for the baz attribute."""
+
+docs = get_attributes_doc(Goo)
+print(docs["bar"])
+print(docs["baz"])
+```
+
+### Decorator `enum_doc`
+
+This is also a class decorator, but it is intended for Enum classes. Instead of setting one doc attribute per attribute to the containing class, it will set the `__doc__` attribute for each enum value.
+
+```py
+from attributes_doc import enum_doc
+from enum import Enum
+
+@enum_doc
+class Foo(Enum):
+	bar = 1
+	"""This is the docstring for the bar attribute."""
+	baz = 2
+	"""This is the docstring for the baz attribute."""
+
+print(Foo.bar.__doc__)
+```
+
+### Function `getdoc`
+
+This function will return the docstring of an attribute of a class.
+
+```py
+from attributes_doc import getdoc
+
+print(getdoc(Foo, "baz")) # Instead of getattr(Foo, "__doc_baz__") above
+```

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This package provides the following functions:
 - `attributes_doc`
 - `get_attributes_doc`
 - `enum_doc`
-- `getdoc`
+- `get_doc`
 
 ### Decorator `attributes_doc`
 
@@ -76,12 +76,12 @@ class Foo(Enum):
 print(Foo.bar.__doc__)
 ```
 
-### Function `getdoc`
+### Function `get_doc`
 
 This function will return the docstring of an attribute of a class.
 
 ```py
-from attributes_doc import getdoc
+from attributes_doc import get_doc
 
-print(getdoc(Foo, "baz")) # Instead of getattr(Foo, "__doc_baz__") above
+print(get_doc(Foo, "baz")) # Instead of getattr(Foo, "__doc_baz__") above
 ```

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open(os.path.join(this_directory, 'README.md')) as f:
 
 setup(
     name='attributes-doc',
-    version='0.2.0',
+    version='0.3.0',
     url='https://github.com/tkukushkin/attributes-doc',
     author='Timofey Kukushkin',
     author_email='tima@kukushkin.me',

--- a/src/attributes_doc/__init__.py
+++ b/src/attributes_doc/__init__.py
@@ -1,4 +1,4 @@
-from ._base import attributes_doc, FStringFound, get_attributes_doc, enum_doc, getdoc
+from ._base import attributes_doc, FStringFound, get_attributes_doc, enum_doc, get_doc
 
 
-__all__ = ["attributes_doc", "FStringFound", "get_attributes_doc", "enum_doc", "getdoc"]
+__all__ = ["attributes_doc", "FStringFound", "get_attributes_doc", "enum_doc", "get_doc"]

--- a/src/attributes_doc/__init__.py
+++ b/src/attributes_doc/__init__.py
@@ -1,4 +1,4 @@
-from ._base import attributes_doc, FStringFound, get_attributes_doc
+from ._base import attributes_doc, FStringFound, get_attributes_doc, enum_doc, getdoc
 
 
-__all__ = ['attributes_doc', 'FStringFound', 'get_attributes_doc']
+__all__ = ["attributes_doc", "FStringFound", "get_attributes_doc", "enum_doc", "getdoc"]

--- a/src/attributes_doc/_base.py
+++ b/src/attributes_doc/_base.py
@@ -2,16 +2,16 @@ import ast
 import inspect
 import sys
 import textwrap
-from typing import Dict, Tuple, Type, TypeVar
+from typing import Any, Dict, Tuple, Type, TypeVar
 
 
-__all__ = ['get_attributes_doc', 'attributes_doc']
+__all__ = ["get_attributes_doc", "attributes_doc", "enum_doc", "getdoc"]
 
 PY35 = sys.version_info[0:2] >= (3, 5)
 
-T = TypeVar('T')
+T = TypeVar("T")
 
-assign_stmts = (ast.Assign, )  # type: Tuple[Type[ast.stmt], ...]
+assign_stmts = (ast.Assign,)  # type: Tuple[Type[ast.stmt], ...]
 if PY35:
     assign_stmts = (ast.Assign, ast.AnnAssign)
 
@@ -22,6 +22,15 @@ class FStringFound(Exception):
 
 def get_attributes_doc(cls):
     # type: (type) -> Dict[str, str]
+    """
+    Get a dictionary of attribute names to docstrings for the given class.
+
+    Args:
+        cls: The class to get the attributes' docstrings for.
+
+    Returns:
+        Dict[str, str]: A dictionary of attribute names to docstrings.
+    """
     result = {}  # type: Dict[str, str]
     for parent in reversed(cls.mro()):
         if cls is object:
@@ -34,10 +43,7 @@ def get_attributes_doc(cls):
         module = ast.parse(source)
         cls_ast = module.body[0]
         for stmt1, stmt2 in zip(cls_ast.body, cls_ast.body[1:]):  # type: ignore
-            if (
-                    not isinstance(stmt1, assign_stmts)
-                    or not isinstance(stmt2, ast.Expr)
-            ):
+            if not isinstance(stmt1, assign_stmts) or not isinstance(stmt2, ast.Expr):
                 continue
             doc_expr_value = stmt2.value
             if PY35 and isinstance(doc_expr_value, ast.JoinedStr):
@@ -54,6 +60,29 @@ def get_attributes_doc(cls):
 
 def attributes_doc(cls):
     # type: (Type[T]) -> Type[T]
+    """Store the docstings of the attributes of a class in attributes named `__doc_NAME__`."""
     for attr_name, attr_doc in get_attributes_doc(cls).items():
-        setattr(cls, '__doc_%s__' % attr_name, attr_doc)
+        setattr(cls, "__doc_%s__" % attr_name, attr_doc)
     return cls
+
+
+def enum_doc(cls):
+    # type: (Type[T]) -> Type[T]
+    """Store the docstrings of the vaules of an enum in their `__doc__` attribute."""
+    for attr_name, attr_doc in get_attributes_doc(cls).items():
+        getattr(cls, attr_name).__doc__ = attr_doc
+    return cls
+
+
+def getdoc(obj, attr_name):
+    # type: (Any, str) -> str | None
+    """Get the docstring of a class attribute of a class or an instance of that class.
+
+    Args:
+        obj: The class or instance with the class attribute to get the docstring of.
+        attr_name: The name of the class attribute to get the docstring of.
+
+    Returns:
+        str | None: The docstring of the class attribute or None if no docstring was found.
+    """
+    return getattr(obj, "__doc_%s__" % attr_name, None)

--- a/src/attributes_doc/_base.py
+++ b/src/attributes_doc/_base.py
@@ -5,7 +5,7 @@ import textwrap
 from typing import Any, Dict, Tuple, Type, TypeVar
 
 
-__all__ = ["get_attributes_doc", "attributes_doc", "enum_doc", "getdoc"]
+__all__ = ["get_attributes_doc", "attributes_doc", "enum_doc", "get_doc"]
 
 PY35 = sys.version_info[0:2] >= (3, 5)
 
@@ -74,7 +74,7 @@ def enum_doc(cls):
     return cls
 
 
-def getdoc(obj, attr_name):
+def get_doc(obj, attr_name):
     # type: (Any, str) -> str | None
     """Get the docstring of a class attribute of a class or an instance of that class.
 

--- a/tests/test_attributes_doc.py
+++ b/tests/test_attributes_doc.py
@@ -1,35 +1,39 @@
-from attributes_doc import attributes_doc, get_attributes_doc
+from attributes_doc import attributes_doc, getdoc
 
 
-class TestGetAttributesDoc(object):
-
+class TestAttributesDoc(object):
     def test__no_doc_strings__no_doc_attributes(self):
-        # arrange
+        # act
+        @attributes_doc
         class Foo1(object):
             a = 1
             b = 2
 
-        # act
-        result = get_attributes_doc(Foo1)
-
         # assert
-        assert result == {}
+        assert not hasattr(Foo1, "__doc_a__")
+        assert not hasattr(Foo1, "__doc_b__")
 
     def test__cls_with_doc_string__no_doc_attributes_for_fields(self):
-        # arrange
+        # act
+        @attributes_doc
         class Foo2(object):
             """Foo Doc"""
+
             a = 1
             b = 2
 
-        # act
-        result = get_attributes_doc(Foo2)
-
         # assert
-        assert result == {}
+        assert Foo2.__doc__ == "Foo Doc"
+        assert not hasattr(Foo2, "__doc_a__")
+        assert getdoc(Foo2, "a") is None
+        assert not hasattr(Foo2, "__doc_b__")
+        assert getdoc(Foo2, "b") is None
 
-    def test__cls_and_one_attr_with_doc_string__expected_doc_attributes_for_cls_and_one_field(self):
-        # arrange
+    def test__cls_and_one_attr_with_doc_string__expected_doc_attributes_for_cls_and_one_field(
+        self,
+    ):
+        # act
+        @attributes_doc
         class Foo3(object):
             """Foo Doc"""
 
@@ -38,103 +42,26 @@ class TestGetAttributesDoc(object):
 
             b = 3
 
-        # act
-        result = get_attributes_doc(Foo3)
-
         # assert
-        assert result == {'a': 'a Doc'}
+        assert Foo3.__doc__ == "Foo Doc"
+        assert Foo3.__doc_a__ == "a Doc"
+        assert getdoc(Foo3, "a") == "a Doc"
+        assert not hasattr(Foo3, "__doc_b__")
+        assert getdoc(Foo3, "b") is None
 
     def test__multiple_assignment__expected_one_doc_string_for_all_fields(self):
-        # arrange
+        # act
+        @attributes_doc
         class Foo4(object):
             a = b = 1
             """a Doc"""
 
             c = 3
 
-        # act
-        result = get_attributes_doc(Foo4)
-
         # assert
-        assert result == {'a': 'a Doc', 'b': 'a Doc'}
-
-    def test__nested_classes(self):
-        # arrange
-        class Bar(object):
-            a = 1
-            """a Doc"""
-
-            b = 2
-            """b Doc"""
-
-            c = 3
-            """c Doc"""
-
-        class BarChild(Bar):
-            a = 5
-            """a Doc 2"""
-
-            c = 3
-
-        # act
-        result = get_attributes_doc(BarChild)
-
-        # assert
-        assert result == {'a': 'a Doc 2', 'b': 'b Doc', 'c': 'c Doc'}
-
-
-class TestAttributesDoc(object):
-
-    def test__no_doc_strings__no_doc_attributes(self):
-        # act
-        @attributes_doc
-        class Foo5(object):
-            a = 1
-            b = 2
-
-        # assert
-        assert not hasattr(Foo5, '__doc_a__')
-        assert not hasattr(Foo5, '__doc_b__')
-
-    def test__cls_with_doc_string__no_doc_attributes_for_fields(self):
-        # act
-        @attributes_doc
-        class Foo6(object):
-            """Foo Doc"""
-            a = 1
-            b = 2
-
-        # assert
-        assert Foo6.__doc__ == 'Foo Doc'
-        assert not hasattr(Foo6, '__doc_a__')
-        assert not hasattr(Foo6, '__doc_b__')
-
-    def test__cls_and_one_attr_with_doc_string__expected_doc_attributes_for_cls_and_one_field(self):
-        # act
-        @attributes_doc
-        class Foo7(object):
-            """Foo Doc"""
-
-            a = 1
-            """a Doc"""
-
-            b = 3
-
-        # assert
-        assert Foo7.__doc__ == 'Foo Doc'
-        assert Foo7.__doc_a__ == 'a Doc'
-        assert not hasattr(Foo7, '__doc_b__')
-
-    def test__multiple_assignment__expected_one_doc_string_for_all_fields(self):
-        # act
-        @attributes_doc
-        class Foo8(object):
-            a = b = 1
-            """a Doc"""
-
-            c = 3
-
-        # assert
-        assert Foo8.__doc_a__ == 'a Doc'
-        assert Foo8.__doc_b__ == 'a Doc'
-        assert not hasattr(Foo8, '__doc_c__')
+        assert Foo4.__doc_a__ == "a Doc"
+        assert getdoc(Foo4, "a") == "a Doc"
+        assert Foo4.__doc_b__ == "a Doc"
+        assert getdoc(Foo4, "b") == "a Doc"
+        assert not hasattr(Foo4, "__doc_c__")
+        assert getdoc(Foo4, "c") is None

--- a/tests/test_attributes_doc.py
+++ b/tests/test_attributes_doc.py
@@ -1,4 +1,4 @@
-from attributes_doc import attributes_doc, getdoc
+from attributes_doc import attributes_doc, get_doc
 
 
 class TestAttributesDoc(object):
@@ -25,9 +25,9 @@ class TestAttributesDoc(object):
         # assert
         assert Foo2.__doc__ == "Foo Doc"
         assert not hasattr(Foo2, "__doc_a__")
-        assert getdoc(Foo2, "a") is None
+        assert get_doc(Foo2, "a") is None
         assert not hasattr(Foo2, "__doc_b__")
-        assert getdoc(Foo2, "b") is None
+        assert get_doc(Foo2, "b") is None
 
     def test__cls_and_one_attr_with_doc_string__expected_doc_attributes_for_cls_and_one_field(
         self,
@@ -45,9 +45,9 @@ class TestAttributesDoc(object):
         # assert
         assert Foo3.__doc__ == "Foo Doc"
         assert Foo3.__doc_a__ == "a Doc"
-        assert getdoc(Foo3, "a") == "a Doc"
+        assert get_doc(Foo3, "a") == "a Doc"
         assert not hasattr(Foo3, "__doc_b__")
-        assert getdoc(Foo3, "b") is None
+        assert get_doc(Foo3, "b") is None
 
     def test__multiple_assignment__expected_one_doc_string_for_all_fields(self):
         # act
@@ -60,8 +60,8 @@ class TestAttributesDoc(object):
 
         # assert
         assert Foo4.__doc_a__ == "a Doc"
-        assert getdoc(Foo4, "a") == "a Doc"
+        assert get_doc(Foo4, "a") == "a Doc"
         assert Foo4.__doc_b__ == "a Doc"
-        assert getdoc(Foo4, "b") == "a Doc"
+        assert get_doc(Foo4, "b") == "a Doc"
         assert not hasattr(Foo4, "__doc_c__")
-        assert getdoc(Foo4, "c") is None
+        assert get_doc(Foo4, "c") is None

--- a/tests/test_both_decorators.py
+++ b/tests/test_both_decorators.py
@@ -1,0 +1,76 @@
+import pytest
+from attributes_doc import enum_doc, attributes_doc
+
+enum = pytest.importorskip("enum")
+
+
+class TestEnumDoc(object):
+    def test__no_doc_strings__no_doc_attributes(self):
+        # act
+        @attributes_doc
+        @enum_doc
+        class Foo(enum.Enum):
+            a = 1
+            b = 2
+
+        # assert
+        assert Foo.a.__doc__ == Foo.__doc__
+        assert not hasattr(Foo, "__doc_a__")
+        assert Foo.b.__doc__ == Foo.__doc__
+        assert not hasattr(Foo, "__doc_b__")
+
+    def test__cls_with_doc_string__no_doc_attributes_for_fields(self):
+        # act
+        @attributes_doc
+        @enum_doc
+        class Foo(enum.Enum):
+            """Foo Doc"""
+
+            a = 1
+            b = 2
+
+        # assert
+        assert Foo.__doc__ == "Foo Doc"
+        assert Foo.a.__doc__ == "Foo Doc"
+        assert not hasattr(Foo, "__doc_a__")
+        assert Foo.b.__doc__ == "Foo Doc"
+        assert not hasattr(Foo, "__doc_b__")
+
+    def test__cls_and_one_attr_with_doc_string__expected_doc_attributes_for_cls_and_one_field(
+        self,
+    ):
+        # act
+        @attributes_doc
+        @enum_doc
+        class Foo(enum.Enum):
+            """Foo Doc"""
+
+            a = 1
+            """a Doc"""
+
+            b = 3
+
+        # assert
+        assert Foo.__doc__ == "Foo Doc"
+        assert Foo.a.__doc__ == "a Doc"
+        assert Foo.__doc_a__ == "a Doc"
+        assert Foo.b.__doc__ == "Foo Doc"
+        assert not hasattr(Foo, "__doc_b__")
+
+    def test__multiple_assignment__expected_one_doc_string_for_all_fields(self):
+        # act
+        @attributes_doc
+        @enum_doc
+        class Foo(enum.Enum):
+            a = b = 1
+            """a Doc"""
+
+            c = 3
+
+        # assert
+        assert Foo.a.__doc__ == "a Doc"
+        assert Foo.__doc_a__ == "a Doc"
+        assert Foo.b.__doc__ == "a Doc"
+        assert Foo.__doc_b__ == "a Doc"
+        assert Foo.c.__doc__ == Foo.__doc__
+        assert not hasattr(Foo, "__doc_c__")

--- a/tests/test_enum_doc.py
+++ b/tests/test_enum_doc.py
@@ -1,0 +1,63 @@
+import pytest
+from attributes_doc import enum_doc
+
+enum = pytest.importorskip("enum")
+
+
+class TestEnumDoc(object):
+    def test__no_doc_strings__no_doc_attributes(self):
+        # act
+        @enum_doc
+        class Foo(enum.Enum):
+            a = 1
+            b = 2
+
+        # assert
+        assert Foo.a.__doc__ == Foo.__doc__
+        assert Foo.b.__doc__ == Foo.__doc__
+
+    def test__cls_with_doc_string__no_doc_attributes_for_fields(self):
+        # act
+        @enum_doc
+        class Foo(enum.Enum):
+            """Foo Doc"""
+
+            a = 1
+            b = 2
+
+        # assert
+        assert Foo.__doc__ == "Foo Doc"
+        assert Foo.a.__doc__ == "Foo Doc"
+        assert Foo.b.__doc__ == "Foo Doc"
+
+    def test__cls_and_one_attr_with_doc_string__expected_doc_attributes_for_cls_and_one_field(
+        self,
+    ):
+        # act
+        @enum_doc
+        class Foo(enum.Enum):
+            """Foo Doc"""
+
+            a = 1
+            """a Doc"""
+
+            b = 3
+
+        # assert
+        assert Foo.__doc__ == "Foo Doc"
+        assert Foo.a.__doc__ == "a Doc"
+        assert Foo.b.__doc__ == "Foo Doc"
+
+    def test__multiple_assignment__expected_one_doc_string_for_all_fields(self):
+        # act
+        @enum_doc
+        class Foo(enum.Enum):
+            a = b = 1
+            """a Doc"""
+
+            c = 3
+
+        # assert
+        assert Foo.a.__doc__ == "a Doc"
+        assert Foo.b.__doc__ == "a Doc"
+        assert Foo.c.__doc__ == Foo.__doc__

--- a/tests/test_get_attributes_doc.py
+++ b/tests/test_get_attributes_doc.py
@@ -1,0 +1,85 @@
+from attributes_doc import get_attributes_doc
+
+
+class TestGetAttributesDoc(object):
+    def test__no_doc_strings__no_doc_attributes(self):
+        # arrange
+        class Foo1(object):
+            a = 1
+            b = 2
+
+        # act
+        result = get_attributes_doc(Foo1)
+
+        # assert
+        assert result == {}
+
+    def test__cls_with_doc_string__no_doc_attributes_for_fields(self):
+        # arrange
+        class Foo2(object):
+            """Foo Doc"""
+
+            a = 1
+            b = 2
+
+        # act
+        result = get_attributes_doc(Foo2)
+
+        # assert
+        assert result == {}
+
+    def test__cls_and_one_attr_with_doc_string__expected_doc_attributes_for_cls_and_one_field(
+        self,
+    ):
+        # arrange
+        class Foo3(object):
+            """Foo Doc"""
+
+            a = 1
+            """a Doc"""
+
+            b = 3
+
+        # act
+        result = get_attributes_doc(Foo3)
+
+        # assert
+        assert result == {"a": "a Doc"}
+
+    def test__multiple_assignment__expected_one_doc_string_for_all_fields(self):
+        # arrange
+        class Foo4(object):
+            a = b = 1
+            """a Doc"""
+
+            c = 3
+
+        # act
+        result = get_attributes_doc(Foo4)
+
+        # assert
+        assert result == {"a": "a Doc", "b": "a Doc"}
+
+    def test__derived_classes(self):
+        # arrange
+        class Bar(object):
+            a = 1
+            """a Doc"""
+
+            b = 2
+            """b Doc"""
+
+            c = 3
+            """c Doc"""
+
+        class BarChild(Bar):
+            a = 5
+            """a Doc 2"""
+
+            c = 3
+
+        # act
+        result = get_attributes_doc(BarChild)
+
+        # assert
+        assert result == {"a": "a Doc 2", "b": "b Doc", "c": "c Doc"}


### PR DESCRIPTION
First off, I added info to the README as well as docstrings to the provided functions

Additionally I added the function `getdoc` for convinience, which simply does `getattr(obj, "__doc_%s__" % attr_name, None)`.

Lastly I added a decorator `enum_doc` similar to `attribute_doc` but intended for enums. When using enums, since each instance is a constant, it makes sense to store the doc string in that instance's __doc__ instead of __doc_NAME__ of the containing class. (If a user wants both, they can use both decorators simultaneously)